### PR TITLE
QMQ-000001: Obtención e identificación de archivos pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.log
 .ipynb_checkpoints
 .DS_Store
+company_files/

--- a/app/adapters/blob/local_fs.py
+++ b/app/adapters/blob/local_fs.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Iterable, Optional
+from datetime import datetime
+import os
+
+from app.ports.outbound.blob_storage import BlobStoragePort, FileInfo
+from app.config.settings import settings
+
+class LocalFileSystemBlob(BlobStoragePort):
+    def __init__(
+        self,
+        exclude_globs: list[str] | None = None,
+        max_pdf_mb: int | None = None,
+    ) -> None:
+        self.exclude_globs = exclude_globs or settings.EXCLUDE_GLOBS
+        self.max_pdf_mb = max_pdf_mb or settings.MAX_PDF_MB
+
+    def list_pdfs(self, base_dir: Path, recursive: bool = True) -> Iterable[FileInfo]:
+        if not base_dir.exists() or not base_dir.is_dir():
+            return []
+
+        # 1) recolectar candidatos por extensión .pdf (case-insensitive)
+        candidates = (
+            base_dir.rglob("*.pdf") if recursive else base_dir.glob("*.pdf")
+        )
+
+        # 2) aplicar exclusiones (globs)
+        def excluded(p: Path) -> bool:
+            return any(p.match(pattern) for pattern in self.exclude_globs)
+
+        # 3) filtrar por tamaño y validar magic header %PDF
+        max_bytes = self.max_pdf_mb * 1024 * 1024
+
+        valid: list[FileInfo] = []
+        for p in candidates:
+            if excluded(p):
+                continue
+            try:
+                st = p.stat()
+                if st.st_size == 0 or st.st_size > max_bytes:
+                    continue
+
+                # Validación rápida del encabezado PDF
+                # Leer primeros bytes sin cargar todo el archivo
+                with p.open("rb") as fh:
+                    header = fh.read(5)  # b'%PDF-'
+                    if not header.startswith(b"%PDF"):
+                        continue
+
+                valid.append(
+                    FileInfo(
+                        path=p,
+                        size_bytes=st.st_size,
+                        modified_at=datetime.fromtimestamp(st.st_mtime),
+                    )
+                )
+            except (OSError, PermissionError):
+                # ignora archivos inaccesibles
+                continue
+
+        # orden opcional por fecha de modificación descendente
+        valid.sort(key=lambda fi: fi.modified_at, reverse=True)
+        return valid
+
+    def read_bytes(self, path: Path, max_bytes: Optional[int] = None) -> bytes:
+        if not path.exists() or not path.is_file():
+            raise FileNotFoundError(str(path))
+        # lectura acotada si se solicita
+        if max_bytes is not None:
+            with path.open("rb") as fh:
+                return fh.read(max_bytes)
+        return path.read_bytes()

--- a/app/application/use_cases/list_local_pdfs.py
+++ b/app/application/use_cases/list_local_pdfs.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Iterable
+from app.ports.outbound.blob_storage import BlobStoragePort, FileInfo
+from app.config.settings import settings
+
+@dataclass
+class ListLocalPdfsInput:
+    recursive: bool = True
+
+@dataclass
+class ListLocalPdfsOutput:
+    files: list[FileInfo]
+
+class ListLocalPdfs:
+    def __init__(self, blob_storage: BlobStoragePort):
+        self.blob = blob_storage
+
+    def execute(self, params: ListLocalPdfsInput) -> ListLocalPdfsOutput:
+        base = settings.COMPANY_FILES_DIR
+        files = list(self.blob.list_pdfs(base, recursive=params.recursive))
+        return ListLocalPdfsOutput(files=files)

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings
+from pydantic import Field
 from pathlib import Path
 
 class Settings(BaseSettings):

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1,0 +1,13 @@
+from pydantic import BaseSettings, Field
+from pathlib import Path
+
+class Settings(BaseSettings):
+    COMPANY_FILES_DIR: Path = Field(default=Path("company_files"))
+    RECURSIVE_SCAN: bool = True
+    MAX_PDF_MB: int = 100
+    EXCLUDE_GLOBS: list[str] = ["**/~$*", "**/.DS_Store", "**/._*"]
+
+    class Config:
+        env_file = ".env"
+
+settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,1 +1,4 @@
-print("RAG chat app")
+from app.ports.inbound.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/app/ports/inbound/cli.py
+++ b/app/ports/inbound/cli.py
@@ -1,0 +1,24 @@
+import argparse
+from app.adapters.blob.local_fs import LocalFileSystemBlob
+from app.application.use_cases.list_local_pdfs import (
+    ListLocalPdfs, ListLocalPdfsInput
+)
+
+def main():
+    parser = argparse.ArgumentParser(description="Listar PDFs en company_files/")
+    parser.add_argument("--non-recursive", action="store_true", help="No recorrer subcarpetas")
+    args = parser.parse_args()
+
+    uc = ListLocalPdfs(LocalFileSystemBlob())
+    out = uc.execute(ListLocalPdfsInput(recursive=not args.non_recursive))
+
+    if not out.files:
+        print("No se encontraron PDFs válidos en company_files/")
+        return
+
+    print(f"Encontrados {len(out.files)} PDF(s):")
+    for f in out.files:
+        print(f"- {f.path}  ({f.size_bytes/1024:.1f} KiB)  mtime={f.modified_at.isoformat(timespec='seconds')}")
+
+if __name__ == "__main__":
+    main()

--- a/app/ports/outbound/blob_storage.py
+++ b/app/ports/outbound/blob_storage.py
@@ -1,0 +1,17 @@
+from typing import Protocol, Iterable, Optional
+from pathlib import Path
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass(frozen=True)
+class FileInfo:
+    path: Path
+    size_bytes: int
+    modified_at: datetime
+
+class BlobStoragePort(Protocol):
+    def list_pdfs(self, base_dir: Path, recursive: bool = True) -> Iterable[FileInfo]:
+        ...
+
+    def read_bytes(self, path: Path, max_bytes: Optional[int] = None) -> bytes:
+        ...

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+annotated-types==0.7.0
+pydantic==2.11.7
+pydantic_core==2.33.2
+typing-inspection==0.4.1
+typing_extensions==4.14.1


### PR DESCRIPTION
Este *pull request* introduce una nueva funcionalidad para listar archivos PDF válidos desde un directorio local, con opciones de filtrado y exclusión, además de proporcionar una interfaz CLI para los usuarios. Los cambios incluyen nuevas configuraciones, un adaptador para el sistema de archivos local, un caso de uso para listar PDFs y un punto de entrada en la CLI. Los cambios más importantes se agrupan a continuación:

**Implementación de almacenamiento de blobs en sistema de archivos local:**

* Se añadió la clase `LocalFileSystemBlob` en `app/adapters/blob/local_fs.py` para escanear directorios en busca de archivos PDF, filtrar por extensión, excluir mediante patrones *glob*, validar cabeceras de archivos, limitar el tamaño de los archivos y ordenar los resultados por fecha de modificación.

**Lógica de dominio y casos de uso:**

* Se definieron el protocolo `BlobStoragePort` y el *dataclass* `FileInfo` en `app/ports/outbound/blob_storage.py` para estandarizar la metadata de archivos y las interacciones con el almacenamiento.
* Se implementó el caso de uso `ListLocalPdfs` en `app/application/use_cases/list_local_pdfs.py` para recuperar y devolver una lista de archivos PDF válidos utilizando el adaptador de almacenamiento de blobs.

**Configuración:**

* Se introdujo la clase `Settings` en `app/config/settings.py` para centralizar la configuración del directorio de archivos, patrones de exclusión, límites de tamaño de PDF y escaneo recursivo, con soporte para variables de entorno.

**Integración CLI y punto de entrada:**

* Se añadió una interfaz CLI en `app/ports/inbound/cli.py` que permite a los usuarios listar PDFs con la opción de desactivar el escaneo recursivo, además de mostrar los detalles de los archivos en un formato amigable.
* Se actualizó `app/main.py` para utilizar el nuevo punto de entrada CLI de la aplicación.

