### PR TITLE
QMQ-000013: Habilitar comandos para cada subproceso de subida de vectores a bd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 .DS_Store
 company_files/
 data/
+report/
+.vscode/

--- a/app/adapters/blob/local_fs.py
+++ b/app/adapters/blob/local_fs.py
@@ -65,6 +65,7 @@ class LocalFileSystemBlob(BlobStoragePort):
         return valid
 
     def read_bytes(self, path: Path, max_bytes: Optional[int] = None) -> bytes:
+        print("---\n### Local File Storage - read_bytes -> bytes:")
         if not path.exists() or not path.is_file():
             raise FileNotFoundError(str(path))
         # lectura acotada si se solicita
@@ -72,5 +73,5 @@ class LocalFileSystemBlob(BlobStoragePort):
             with path.open("rb") as fh:
                 return fh.read(max_bytes)
         bytes = path.read_bytes()
-        print(f"{len(bytes)} bytes obtenidos de {path}")
+        print(f"- {len(bytes)} bytes obtenidos de {path}\n---")
         return bytes

--- a/app/adapters/blob/local_fs.py
+++ b/app/adapters/blob/local_fs.py
@@ -71,4 +71,6 @@ class LocalFileSystemBlob(BlobStoragePort):
         if max_bytes is not None:
             with path.open("rb") as fh:
                 return fh.read(max_bytes)
-        return path.read_bytes()
+        bytes = path.read_bytes()
+        print(f"{len(bytes)} bytes obtenidos de {path}")
+        return bytes

--- a/app/adapters/embedding/bedrock_titan_embedder.py
+++ b/app/adapters/embedding/bedrock_titan_embedder.py
@@ -61,7 +61,7 @@ class BedrockTitanEmbedder(EmbedderPort):
     def _embed_one(self, text: str) -> list[float]:
         # Construcción del cuerpo según Titan v2.
         # Para v2, el campo principal es "inputText". La dimensión es opcional.
-        body = {"inputText": text}
+        body: dict[str, str | int] = {"inputText": text}
         if self.dim:
             # Algunas versiones aceptan "dimensions"; otras "embeddingConfig".
             # Usamos "dimensions" si dim está definido; si tu región requiere el otro nombre, cámbialo aquí.

--- a/app/adapters/embedding/bedrock_titan_embedder.py
+++ b/app/adapters/embedding/bedrock_titan_embedder.py
@@ -46,14 +46,22 @@ class BedrockTitanEmbedder(EmbedderPort):
     def embed_texts(self, texts: List[str]) -> List[list[float]]:
         if not texts:
             return []
+        
+        print(f"### Bedrock Titan Embedder - embed_texts -> List[list[float]]")
 
         vectors: List[list[float]] = []
-        for i in range(0, len(texts), self.batch_size):
+        for i in range(0, len(texts), self.batch_size):            
             batch = texts[i : i + self.batch_size]
+
+            print(f"Procesando batch de {len(batch)} textos (total {len(texts)})...")
+
             # Titan embeddings procesa un texto por invocación -> llamamos por cada item del batch
             for t in batch:
                 vec = self._embed_one(t)
+                print(f"\r\033[2K- Vector recibido ({len(vec)} dims). ", end='', flush=True)  # \033[2K limpia la línea
                 vectors.append(vec)
+                print(f"-> {len(vectors)}/{len(texts)} embeddings procesados.", end='', flush=True)  # \033[2K limpia la línea
+        print("\n---")
         return vectors
 
     # --------------- Internos ---------------
@@ -73,9 +81,11 @@ class BedrockTitanEmbedder(EmbedderPort):
         backoff = 1.0
         while True:
             try:
+                print(f"\r\033[2K- Invocando modelo {self.model_id}...", end='', flush=True)  # \033[2K limpia la línea
                 resp = self.client.invoke_model(modelId=self.model_id, body=payload)
                 # bedrock-runtime retorna bytes en resp["body"]
                 raw = resp.get("body").read()
+                print(f"\r\033[2K- Respuesta recibida ({len(raw)} bytes). Procesando...", end='', flush=True)  # \033[2K limpia la línea
                 data = json.loads(raw.decode("utf-8"))
                 emb = data.get("embedding") or data.get("vector")  # por si la clave difiere
                 if not isinstance(emb, list):

--- a/app/adapters/extract/pymupdf_text_extractor.py
+++ b/app/adapters/extract/pymupdf_text_extractor.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass
 from io import BytesIO
 from typing import Optional, List
 
+import pathlib
 import pymupdf
+import pymupdf4llm
 from app.ports.outbound.text_extractor import TextExtractorPort, TextExtractionResult
 
 
@@ -35,10 +37,11 @@ class PyMuPDFTextExtractor(TextExtractorPort):
             limit = min(page_total, hard_cap) if hard_cap is not None else page_total
 
             for i in range(limit):
-                page = doc.load_page(i)
-                txt = page.get_textpage().extractTEXT(sort=self.cfg.sort_text)
-                # Normaliza saltos finales de PyMuPDF
-                pages.append(txt.rstrip("\n"))
+                """ page = doc.load_page(i)
+                txt = page.get_textpage().extractTEXT(sort=self.cfg.sort_text) """
+                md_page_text = pymupdf4llm.to_markdown(doc, pages=[i])
+                
+                pages.append(md_page_text.rstrip("\n"))
 
             meta = doc.metadata or {}
             producer = None
@@ -51,7 +54,8 @@ class PyMuPDFTextExtractor(TextExtractorPort):
             for i, p in enumerate(pages):
                 print(f"- Página {i+1} ({len(p)} chars):\n  {p[:50]!r}...")
 
-            print("---")
+            # Reporte de extracción
+            pathlib.Path("report/text-extraction.md").write_text("\n\n---\n**END OF PAGE**\n---\n\n".join(pages), encoding="utf-8")
 
             return TextExtractionResult(
                 pages=pages,

--- a/app/adapters/extract/pymupdf_text_extractor.py
+++ b/app/adapters/extract/pymupdf_text_extractor.py
@@ -21,6 +21,7 @@ class PyMuPDFTextExtractor(TextExtractorPort):
         self.cfg = config or PyMuPDFConfig()
 
     def extract_from_bytes(self, data: bytes, max_pages: Optional[int] = None) -> TextExtractionResult:
+        print("### PyMuPDF Text Extractor - extract_from_bytes -> pages: List[str], page_count: int, producer: Optional[str]:")
         hard_cap = max_pages if max_pages is not None else self.cfg.max_pages
 
         doc = pymupdf.open(stream=data)
@@ -44,6 +45,13 @@ class PyMuPDFTextExtractor(TextExtractorPort):
             # Clave típica en metadata es 'producer'
             if isinstance(meta, dict):
                 producer = meta.get("producer") or meta.get("Producer")
+
+            print(f"- {len(pages)} páginas extraídas (de {page_total})")
+
+            for i, p in enumerate(pages):
+                print(f"- Página {i+1} ({len(p)} chars):\n  {p[:50]!r}...")
+
+            print("---")
 
             return TextExtractionResult(
                 pages=pages,

--- a/app/adapters/extract/pymupdf_text_extractor.py
+++ b/app/adapters/extract/pymupdf_text_extractor.py
@@ -35,7 +35,7 @@ class PyMuPDFTextExtractor(TextExtractorPort):
 
             for i in range(limit):
                 page = doc.load_page(i)
-                txt = page.get_text("text", sort=self.cfg.sort_text)
+                txt = page.get_textpage().extractTEXT(sort=self.cfg.sort_text)
                 # Normaliza saltos finales de PyMuPDF
                 pages.append(txt.rstrip("\n"))
 

--- a/app/adapters/vector_store/weaviate_store.py
+++ b/app/adapters/vector_store/weaviate_store.py
@@ -3,7 +3,7 @@ from uuid import uuid5, NAMESPACE_URL
 
 import weaviate
 from weaviate.classes.init import Auth, AdditionalConfig, Timeout
-from weaviate.classes.config import Configure, Property, DataType
+from weaviate.classes.config import Configure, Property, DataType, VectorDistances
 from weaviate.classes.data import DataObject
 from weaviate.exceptions import WeaviateBaseError
 
@@ -63,7 +63,7 @@ class WeaviateVectorStore(VectorStorePort):
             batch_chunks = chunks[i:i+bs]
             batch_vecs = vectors[i:i+bs]
 
-            objs: list[DataObject] = []
+            objs: list = []
             id_map: list[tuple[dict, list[float], str]] = []
 
             for c, vec in zip(batch_chunks, batch_vecs):
@@ -135,9 +135,9 @@ class WeaviateVectorStore(VectorStorePort):
     def _metric_from_str(s: str):
         s = (s or "cosine").lower()
         if s == "cosine":
-            return "cosine"
+            return VectorDistances.COSINE
         if s in ("dot", "dotproduct", "dot_product"):
-            return "dot"
+            return VectorDistances.DOT
         if s in ("l2", "l2-squared", "euclidean"):
-            return "l2-squared"
-        return "cosine"
+            return VectorDistances.L2_SQUARED
+        return VectorDistances.COSINE

--- a/app/adapters/vector_store/weaviate_store.py
+++ b/app/adapters/vector_store/weaviate_store.py
@@ -44,10 +44,13 @@ class WeaviateVectorStore(VectorStorePort):
             pass
 
     def upsert_chunks(self, doc_id: str, chunks: List, vectors: List[list[float]], company_id: str = "default_company", collection_name: Optional[str] = None) -> int:
+        print(f"### Weaviate Vector Store - upsert_chunks -> int")
+
         if len(chunks) != len(vectors):
             raise ValueError("chunks y vectors deben tener la misma longitud.")
         if not chunks:
             return 0
+
         dim = len(vectors[0])
         if any(len(v) != dim for v in vectors):
             raise ValueError("Todos los vectores deben tener la misma dimensión.")
@@ -55,10 +58,16 @@ class WeaviateVectorStore(VectorStorePort):
         # Use the provided collection name or fall back to default
         target_collection = collection_name or self.collection_name
         self._ensure_collection_exists(target_collection)
+
+        print(f"- Upsert de {len(chunks)} chunks en Weaviate collection '{target_collection}'...")
+
         coll = self.client.collections.get(target_collection)
 
         total = 0
         bs = self.batch_size
+
+        print(f"- Usando batch size {bs}, distancia '{self.distance}', dimensión {dim}.")
+
         for i in range(0, len(chunks), bs):
             batch_chunks = chunks[i:i+bs]
             batch_vecs = vectors[i:i+bs]
@@ -84,8 +93,11 @@ class WeaviateVectorStore(VectorStorePort):
                 id_map.append((props, vec, uid))
 
             try:
+                print(f"\r\033[2K- Upserting batch de {len(objs)} chunks... ", end='', flush=True)  # \033[2K limpia la línea
                 # intento rápido en batch
                 coll.data.insert_many(objs)
+                print(f"-> Upsert completado con éxito. ({len(objs)} items subidos).")
+
                 total += len(objs)
             except WeaviateBaseError:
                 # fallback: upsert por ítem (insert → replace si ya existe)
@@ -96,7 +108,7 @@ class WeaviateVectorStore(VectorStorePort):
                         # si ya existe u otro conflicto, hacemos replace (sobrescribe todo)
                         coll.data.replace(uuid=uid, properties=props, vector=vec)
                     total += 1
-
+        print(f"- Upsert finalizado. Total chunks cargados: {total}.\n---")
         return total
 
 

--- a/app/application/use_cases/embed_and_upsert_company_pdfs.py
+++ b/app/application/use_cases/embed_and_upsert_company_pdfs.py
@@ -65,6 +65,7 @@ class EmbedAndUpsertCompanyPdfs:
 
         for pdf_file in pdf_files:
             try:
+                print(f"🕑 Now processing {pdf_file}...")
                 # Use relative path from company_files
                 relative_path = Path(params.company_id) / pdf_file.name
                 
@@ -75,7 +76,7 @@ class EmbedAndUpsertCompanyPdfs:
                     chunker_cfg=params.chunker_cfg,
                     quality_cfg=params.quality_cfg,
                 ))
-                
+
                 # Then upsert to collection with company name
                 doc_id = pdf_file.stem
                 written = self.vector_store.upsert_chunks(
@@ -85,7 +86,7 @@ class EmbedAndUpsertCompanyPdfs:
                     company_id=params.company_id,
                     collection_name=params.company_id  # Use company_id as collection name
                 )
-                
+
                 reports.append(CompanyFileReport(
                     file_path=pdf_file,
                     success=True,
@@ -95,6 +96,8 @@ class EmbedAndUpsertCompanyPdfs:
                 
                 total_chunks += written
                 successful_count += 1
+
+                print(f"✅ Finished processing {pdf_file}.\n")
                 
             except Exception as e:
                 reports.append(CompanyFileReport(
@@ -118,7 +121,7 @@ class EmbedAndUpsertCompanyPdfs:
         if not company_folder.exists():
             return []
         
-        pdf_files = []
+        pdf_files: List[Path] = []
         for file_path in company_folder.iterdir():
             if file_path.is_file() and file_path.suffix.lower() == '.pdf':
                 pdf_files.append(file_path)

--- a/app/application/use_cases/embed_and_upsert_company_pdfs.py
+++ b/app/application/use_cases/embed_and_upsert_company_pdfs.py
@@ -65,7 +65,7 @@ class EmbedAndUpsertCompanyPdfs:
 
         for pdf_file in pdf_files:
             try:
-                print(f"🕑 Now processing {pdf_file}...")
+                print(f"🕑 Procesando archivo {pdf_file.name}...")
                 # Use relative path from company_files
                 relative_path = Path(params.company_id) / pdf_file.name
                 
@@ -97,7 +97,7 @@ class EmbedAndUpsertCompanyPdfs:
                 total_chunks += written
                 successful_count += 1
 
-                print(f"✅ Finished processing {pdf_file}.\n")
+                print(f"\n✅ Procesamiento exitoso del archivo {pdf_file.name}.\n\n---")
                 
             except Exception as e:
                 reports.append(CompanyFileReport(

--- a/app/application/use_cases/embed_chunks_from_pdf.py
+++ b/app/application/use_cases/embed_chunks_from_pdf.py
@@ -55,7 +55,10 @@ class EmbedChunksFromPdf:
 
         # 2) quality gate
         quality = ChunkQuality(params.quality_cfg) if params.quality_cfg else ChunkQuality()
+
+        print("### Chunk Quality - good")
         good = [c for c in chunks if quality.good(c)]
+        print("\n---")
 
         # 3) embeddings (solo texto)
         texts = [c.text for c in good]

--- a/app/domain/services/chunk_quality.py
+++ b/app/domain/services/chunk_quality.py
@@ -4,8 +4,10 @@ from typing import Protocol
 
 # Para no acoplar al tipo concreto del chunk global:
 class HasTextTok(Protocol):
-    text: str
-    token_count: int
+    @property
+    def text(self) -> str: ...
+    @property
+    def token_count(self) -> int: ...
 
 @dataclass(frozen=True)
 class QualityConfig:

--- a/app/domain/services/chunk_quality.py
+++ b/app/domain/services/chunk_quality.py
@@ -21,13 +21,25 @@ class ChunkQuality:
         self.cfg = cfg or QualityConfig()
 
     def good(self, c: HasTextTok) -> bool:
+
         text = c.text or ""
-        if c.token_count < self.cfg.min_tokens: return False
-        if len(text) < self.cfg.min_chars: return False
+        if c.token_count < self.cfg.min_tokens: return False # Cantidad mínima de tokens
+        print(f"\r\033[2K1/5 Validaciones exitosas", end='', flush=True)  # \033[2K limpia la línea
+        
+        if len(text) < self.cfg.min_chars: return False # Cantidad mínima de caracteres
+        print(f"\r\033[2K2/5 Validaciones exitosas", end='', flush=True)
+
         letters = sum(ch.isalpha() for ch in text)
-        if (letters / max(len(text), 1)) < self.cfg.min_alpha_ratio: return False
+        if (letters / max(len(text), 1)) < self.cfg.min_alpha_ratio: return False # Ratio de letras a chars
+        print(f"\r\033[2K3/5 Validaciones exitosas", end='', flush=True)
+
         words = [w for w in text.split() if w.isalpha()]
-        if not words: return False
+        if not words: return False # Validar palabras alfabéticas
+        print(f"\r\033[2K4/5 Validaciones exitosas", end='', flush=True)
+
         uniq = len(set(w.lower() for w in words))
-        if (uniq / len(words)) < self.cfg.min_unique_ratio: return False
+        if (uniq / len(words)) < self.cfg.min_unique_ratio: return False # Ratio de palabras únicas
+        print(f"\r\033[2K5/5 Validaciones exitosas", end='', flush=True)
+
+
         return True

--- a/app/domain/services/chunker_global.py
+++ b/app/domain/services/chunker_global.py
@@ -40,8 +40,11 @@ class GlobalTokenChunker:
 
     def chunk_document(self, pages: List[str]) -> Tuple[List[GlobalChunk], str]:
         """Une las páginas, realiza chunking global y devuelve (chunks, full_text)."""
+        print("### Global Token Chunker - Chunk document")
         full_text, page_offsets = self._join_pages_and_offsets(pages)
+        print(f"- Documento unido tiene {len(full_text)} chars y {len(page_offsets)} páginas.")
         chunks = self._chunk_over_text(full_text, page_offsets)
+        print(f"- Chunking global produjo {len(chunks)} chunks.\n---")
         return chunks, full_text
 
     # ---------- Internos ----------

--- a/app/domain/services/text_normalizer.py
+++ b/app/domain/services/text_normalizer.py
@@ -13,7 +13,7 @@ _ZW_CHARS = [
 
 @dataclass(frozen=True)
 class NormalizerConfig:
-    unicode_form: str = "NFC"          # "NFC" / "NFKC"
+    unicode_form: unicodedata._NormalizationForm = "NFC"          # "NFC" / "NFKC"
     collapse_whitespace: bool = True   # colapsar espacios en blanco consecutivos
     strip_control_chars: bool = True   # remover \x00-\x1F excepto \n\t
     normalize_nbsp: bool = True        # reemplaza NBSP por espacio normal

--- a/app/domain/services/text_normalizer.py
+++ b/app/domain/services/text_normalizer.py
@@ -27,8 +27,17 @@ class TextNormalizer:
         self.cfg = cfg or NormalizerConfig()
 
     def normalize_pages(self, pages: List[str]) -> List[str]:
+        print("### Text Normalizer - normalize_pages -> List[str]:")
         """Normaliza cada página independientemente (mismo largo que 'pages')."""
-        return [self._normalize_page(p) for p in pages]
+        normalization_result: List[str] = []
+        for i, p in enumerate(pages):
+            print(f"Normalización de página {i+1}")
+            normalization_result.append(self._normalize_page(p))
+            print(f"-> Página {i+1} normalizada ({len(p)} -> {len(normalization_result[-1])} chars).")
+
+        print("---")
+
+        return normalization_result
 
     def normalize_and_join(self, pages: List[str]) -> str:
         """Normaliza y devuelve un único string (todas las páginas unidas)."""
@@ -41,27 +50,40 @@ class TextNormalizer:
     def _normalize_page(self, text: str) -> str:
         t = text or ""
 
+        print("Subprocesos:", end=" ")
+
         # 1) Unicode canonical / compatibility normalization
         if self.cfg.unicode_form:
             t = unicodedata.normalize(self.cfg.unicode_form, t)
+            print(f"\r\033[2K- 1/7 subprocesos completados", end='', flush=True)  # \033[2K limpia la línea
+
 
         # 2) Normaliza NBSP (no-break space) a espacio regular
         if self.cfg.normalize_nbsp:
             t = t.replace("\u00A0", " ")
+            print(f"\r\033[2K- 2/7 subprocesos completados", end='', flush=True)  # \033[2K limpia la línea
+
 
         # 3) Remueve zero-width chars
         if self.cfg.remove_zero_width:
             for zw in _ZW_CHARS:
                 t = t.replace(zw, "")
+            print(f"\r\033[2K- 3/7 subprocesos completados", end='', flush=True)  # \033[2K limpia la línea
+            
 
         # 4) Remueve caracteres de control (excepto \n, \t)
         if self.cfg.strip_control_chars:
             t = re.sub(r"[\x00-\x08\x0B-\x0C\x0E-\x1F]", "", t)
+            print("(4) Caracteres de control removidos.", end=" ")
+            print(f"\r\033[2K- 4/7 subprocesos completados", end='', flush=True)  # \033[2K limpia la línea
+
 
         # 5) Repara guiones de final de línea (hyphenation) si parecen cortes
         #    Regla heurística: 'palabra-\ncontinuacion' -> 'palabracontinuacion'
         if self.cfg.fix_broken_hyphens:
             t = re.sub(r"(\w)-\n(\w)", r"\1\2", t)
+            print(f"\r\033[2K- 5/7 subprocesos completados", end='', flush=True)  # \033[2K limpia la línea
+
 
         # 6) Unir saltos de línea “suaves” en el mismo párrafo
         #    Heurística: si una línea termina con letra/número y la siguiente inicia en minúscula,
@@ -77,6 +99,7 @@ class TextNormalizer:
             # Restaura párrafos
             if self.cfg.keep_double_newlines:
                 t = t.replace(placeholder, "\n\n")
+            print(f"\r\033[2K- 6/7 subprocesos completados", end='', flush=True)  # \033[2K limpia la línea
 
         # 7) Colapsa espacios en blanco redundantes (sin tocar dobles \n\n)
         if self.cfg.collapse_whitespace:
@@ -86,6 +109,9 @@ class TextNormalizer:
             t = re.sub(r"[ \t]+\n", "\n", t)
             # Trim de cada línea
             t = "\n".join(line.strip() for line in t.splitlines())
+            print(f"\r\033[2K- 7/7 subprocesos completados", end=' ', flush=True)
+
+        global_trim = t.strip()
 
         # Trim global final
-        return t.strip()
+        return global_trim

--- a/app/ports/inbound/cli.py
+++ b/app/ports/inbound/cli.py
@@ -128,7 +128,7 @@ def main():
         print(f"Archivo: {out.source_path}")
         print(f"Páginas extraídas: {out.result.page_count}")
         for i, page in enumerate(out.result.pages, start=1):
-            print(f"\n--- Página {i} ---\n{page[:1000]}")  # primeras 1000 chars para inspección
+            print(f"\n--- Página {i} ---\n{page[:50]}...")  # primeras 1000 chars para inspección
 
     elif args.cmd == "chunk-global":
         blob = LocalFileSystemBlob()

--- a/app/ports/outbound/vector_store.py
+++ b/app/ports/outbound/vector_store.py
@@ -1,10 +1,7 @@
 # src/app/ports/outbound/vector_store.py
 from __future__ import annotations
-from typing import Protocol, List
+from typing import Protocol, List, Optional
 
 class VectorStorePort(Protocol):
-    def upsert_chunks(self, doc_id: str, chunks: List, vectors: List[list[float]], company_id: str = "default_company") -> int:
-        ...
-
-    def create_collection(self) -> None:
+    def upsert_chunks(self, doc_id: str, chunks: List, vectors: List[list[float]], company_id: str = "default_company", collection_name: Optional[str] = None) -> int:
         ...


### PR DESCRIPTION
Este pull request introduce un registro y salida de depuración extensivos en múltiples módulos para facilitar el rastreo y la comprensión de los flujos de procesamiento de PDF, embeddings, fragmentación (*chunking*), normalización y almacenamiento vectorial. Los cambios agregan mensajes informativos en etapas clave del *pipeline* de datos, mejoran la seguridad de tipos y aumentan la claridad del código. Además, se incluyen algunas refactorizaciones menores y mejoras en los tipos.

**Mejoras en Logging y Depuración**

* Se agregaron mensajes detallados para reportar el progreso y el estado interno en los siguientes módulos y métodos:

  * Extracción de PDF (`pymupdf_text_extractor.py`), incluyendo extracción de páginas, vistas previas de contenido e informes de extracción. [\[1\]](diffhunk://#diff-10c7c87cc9b89fe0cf8e9e83e3a130832364787608b181b76d4c82e51579f443R26) [\[2\]](diffhunk://#diff-10c7c87cc9b89fe0cf8e9e83e3a130832364787608b181b76d4c82e51579f443L37-R59)
  * Flujo de embeddings (`bedrock_titan_embedder.py`), con registro de procesamiento por lotes, recepción de vectores e invocación del modelo. [\[1\]](diffhunk://#diff-0d7819865225416d513fc7ab22bb570f6df8a2576d221927d634b49c504eef24R50-R72) [\[2\]](diffhunk://#diff-0d7819865225416d513fc7ab22bb570f6df8a2576d221927d634b49c504eef24R84-R88)
  * Inserciones en el *vector store* (`weaviate_store.py`), incluyendo tamaño de lote, conteo de fragmentos y reportes de éxito/falla. [\[1\]](diffhunk://#diff-7096b0064a1b6bfe6685441f3efa03589f25653f1a604ca7670ac647d1b45188R47-R75) [\[2\]](diffhunk://#diff-7096b0064a1b6bfe6685441f3efa03589f25653f1a604ca7670ac647d1b45188R96-R100) [\[3\]](diffhunk://#diff-7096b0064a1b6bfe6685441f3efa03589f25653f1a604ca7670ac647d1b45188L99-R111)
  * Validación de calidad de *chunks* (`chunk_quality.py`), mostrando el progreso de validación paso a paso.
  * Normalización de texto (`text_normalizer.py`), con normalización por página y actualizaciones de finalización de subprocesos. [\[1\]](diffhunk://#diff-50bb87ffc5fa63c6f68a19a42f9692e77f489d75c9f83008aaec60fa341b0e87R30-R40) [\[2\]](diffhunk://#diff-50bb87ffc5fa63c6f68a19a42f9692e77f489d75c9f83008aaec60fa341b0e87R53-R86) [\[3\]](diffhunk://#diff-50bb87ffc5fa63c6f68a19a42f9692e77f489d75c9f83008aaec60fa341b0e87R102) [\[4\]](diffhunk://#diff-50bb87ffc5fa63c6f68a19a42f9692e77f489d75c9f83008aaec60fa341b0e87R112-R117)
  * Proceso de *chunking* (`chunker_global.py`) y orquestación de casos de uso (`embed_and_upsert_company_pdfs.py`, `embed_chunks_from_pdf.py`), reportando estadísticas de documentos y fragmentos. [\[1\]](diffhunk://#diff-8434a4f3c05479b262662405aba3357226f171351404f3294e298b2af234305bR43-R47) [\[2\]](diffhunk://#diff-816c920854703857225e02a4c7977afc1e2b693b5f2a2ef6630dab329e2d00eeR68) [\[3\]](diffhunk://#diff-816c920854703857225e02a4c7977afc1e2b693b5f2a2ef6630dab329e2d00eeR100-R101) [\[4\]](diffhunk://#diff-4ad92f1a170a1cdf759dde667130f235dfa03fdfab8522daa54e012611d2a062R58-R61)

**Mejoras en Tipado y Calidad de Código**

* Se actualizaron las anotaciones de tipo para mayor claridad y corrección, incluyendo tipos más estrictos en objetos de configuración e interfaces de protocolo. [\[1\]](diffhunk://#diff-04770baee336fa89937bd9eb594a569cf355d6d59954727371a93e761295b027L7-R10) [\[2\]](diffhunk://#diff-50bb87ffc5fa63c6f68a19a42f9692e77f489d75c9f83008aaec60fa341b0e87L16-R16) [\[3\]](diffhunk://#diff-816c920854703857225e02a4c7977afc1e2b693b5f2a2ef6630dab329e2d00eeL121-R124)
* Refactorización menor para mejorar la legibilidad y seguridad, como inicializar listas con tipos explícitos y refinar el manejo de objetos por lotes. [\[1\]](diffhunk://#diff-816c920854703857225e02a4c7977afc1e2b693b5f2a2ef6630dab329e2d00eeL121-R124) [\[2\]](diffhunk://#diff-7096b0064a1b6bfe6685441f3efa03589f25653f1a604ca7670ac647d1b45188R96-R100)

**Actualizaciones de Integración y Compatibilidad**

* Se mejoró la selección de métricas para la distancia vectorial en la integración con Weaviate, utilizando valores de *enum* en lugar de cadenas directas.
* Se agregaron importaciones necesarias de librerías externas para soportar la extracción en markdown y otras funcionalidades.

**Ajustes en la Salida para el Usuario**

* Se modificó la salida de la CLI para mostrar una vista previa más corta del contenido de las páginas extraídas, facilitando su inspección.

**Referencias:**  
[[1]](diffhunk://#diff-10c7c87cc9b89fe0cf8e9e83e3a130832364787608b181b76d4c82e51579f443R26) [[2]](diffhunk://#diff-10c7c87cc9b89fe0cf8e9e83e3a130832364787608b181b76d4c82e51579f443L37-R59) [[3]](diffhunk://#diff-0d7819865225416d513fc7ab22bb570f6df8a2576d221927d634b49c504eef24R50-R72) [[4]](diffhunk://#diff-0d7819865225416d513fc7ab22bb570f6df8a2576d221927d634b49c504eef24R84-R88) [[5]](diffhunk://#diff-7096b0064a1b6bfe6685441f3efa03589f25653f1a604ca7670ac647d1b45188R47-R75) [[6]](diffhunk://#diff-7096b0064a1b6bfe6685441f3efa03589f25653f1a604ca7670ac647d1b45188R96-R100) [[7]](diffhunk://#diff-7096b0064a1b6bfe6685441f3efa03589f25653f1a604ca7670ac647d1b45188L99-R111) [[8]](diffhunk://#diff-04770baee336fa89937bd9eb594a569cf355d6d59954727371a93e761295b027R24-R44) [[9]](diffhunk://#diff-50bb87ffc5fa63c6f68a19a42f9692e77f489d75c9f83008aaec60fa341b0e87R30-R40) [[10]](diffhunk://#diff-50bb87ffc5fa63c6f68a19a42f9692e77f489d75c9f83008aaec60fa341b0e87R53-R86) [[11]](diffhunk://#diff-50bb87ffc5fa63c6f68a19a42f9692e77f489d75c9f83008aaec60fa341b0e87R102) [[12]](diffhunk://#diff-50bb87ffc5fa63c6f68a19a42f9692e77f489d75c9f83008aaec60fa341b0e87R112-R117) [[13]](diffhunk://#diff-8434a4f3c05479b262662405aba3357226f171351404f3294e298b2af234305bR43-R47) [[14]](diffhunk://#diff-816c920854703857225e02a4c7977afc1e2b693b5f2a2ef6630dab329e2d00eeR68) [[15]](diffhunk://#diff-816c920854703857225e02a4c7977afc1e2b693b5f2a2ef6630dab329e2d00eeR100-R101) [[16]](diffhunk://#diff-816c920854703857225e02a4c7977afc1e2b693b5f2a2ef6630dab329e2d00eeL121-R124) [[17]](diffhunk://#diff-4ad92f1a170a1cdf759dde667130f235dfa03fdfab8522daa54e012611d2a062R58-R61) [[18]](diffhunk://#diff-04770baee336fa89937bd9eb594a569cf355d6d59954727371a93e761295b027L7-R10) [[19]](diffhunk://#diff-50bb87ffc5fa63c6f68a19a42f9692e77f489d75c9f83008aaec60fa341b0e87L16-R16) [[20]](diffhunk://#diff-7096b0064a1b6bfe6685441f3efa03589f25653f1a604ca7670ac647d1b45188L138-R155) [[21]](diffhunk://#diff-10c7c87cc9b89fe0cf8e9e83e3a130832364787608b181b76d4c82e51579f443R6-R8) [[22]](diffhunk://#diff-1f14d8ff7ed67c762b218daf8aa4360e2bd89a887c767c44750fad0e473e7392L131-R131)