### PR TITLE
QMQ-000032: habilitar parámetro área en comando que carga vectores a la bd vectorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ data/
 report/
 .vscode/
 reports/
+*.local.*

--- a/app/application/use_cases/embed_and_upsert_files_with_metadata.py
+++ b/app/application/use_cases/embed_and_upsert_files_with_metadata.py
@@ -1,0 +1,134 @@
+# app/application/use_cases/embed_and_upsert_files_with_metadata.py
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from app.ports.outbound.blob_storage import BlobStoragePort
+from app.ports.outbound.text_extractor import TextExtractorPort
+from app.ports.outbound.embedder import EmbedderPort
+from app.ports.outbound.vector_store import VectorStorePort
+
+from app.domain.services.md_text_normalizer import MdTextNormalizer
+from app.ports.outbound.chunker import ChunkerPort, ChunkerConfig
+from app.domain.services.chunk_quality import QualityConfig
+
+from app.application.use_cases.embed_chunks_from_pdf import (
+    EmbedChunksFromPdf, EmbedChunksFromPdfInput
+)
+
+@dataclass
+class FileWithMetadataReport:
+    file_path: Path
+    success: bool
+    chunks_written: int
+    doc_id: str
+    error_message: Optional[str] = None
+
+@dataclass
+class EmbedAndUpsertFilesWithMetadataInput:
+    company_name: str
+    area_name: str
+    max_pages: Optional[int] = None
+    chunker_cfg: Optional[ChunkerConfig] = None
+    quality_cfg: Optional[QualityConfig] = None
+
+@dataclass
+class EmbedAndUpsertFilesWithMetadataOutput:
+    company_name: str
+    area_name: str
+    total_files: int
+    successful_files: int
+    total_chunks_written: int
+    reports: List[FileWithMetadataReport]
+
+class EmbedAndUpsertFilesWithMetadata:
+    def __init__(
+        self,
+        blob: BlobStoragePort,
+        extractor: TextExtractorPort,
+        normalizer: MdTextNormalizer,
+        chunker: ChunkerPort,
+        embedder: EmbedderPort,
+        vector_store: VectorStorePort,
+    ) -> None:
+        self.embed_uc = EmbedChunksFromPdf(blob, extractor, normalizer, chunker, embedder)
+        self.vector_store = vector_store
+        self.blob = blob
+
+    def execute(self, params: EmbedAndUpsertFilesWithMetadataInput) -> EmbedAndUpsertFilesWithMetadataOutput:
+        # Get all PDF files from company_files/files/
+        files_folder = Path("company_files") / "files"
+        pdf_files = self._get_pdf_files(files_folder)
+        
+        reports: List[FileWithMetadataReport] = []
+        total_chunks = 0
+        successful_count = 0
+
+        for pdf_file in pdf_files:
+            try:
+                print(f"🕑 Procesando archivo {pdf_file.name} para company_id={params.company_name} area={params.area_name}...")
+                # Use relative path from company_files
+                relative_path = Path("files") / pdf_file.name
+                
+                # First get embeddings
+                embed_result = self.embed_uc.execute(EmbedChunksFromPdfInput(
+                    relative_path=relative_path,
+                    max_pages=params.max_pages,
+                    chunker_cfg=params.chunker_cfg,
+                    quality_cfg=params.quality_cfg,
+                ))
+
+                # Then upsert to collection with company name as collection and specified metadata
+                doc_id = pdf_file.stem
+                written = self.vector_store.upsert_chunks(
+                    doc_id=doc_id,
+                    chunks=embed_result.chunks,  # type: ignore[arg-type]
+                    vectors=embed_result.vectors,
+                    company_id=params.company_name,
+                    area=params.area_name,
+                    collection_name=params.company_name  # Use company_name as collection name
+                )
+
+                reports.append(FileWithMetadataReport(
+                    file_path=pdf_file,
+                    success=True,
+                    chunks_written=written,
+                    doc_id=doc_id,
+                ))
+                
+                total_chunks += written
+                successful_count += 1
+
+                print(f"✅ Procesamiento exitoso del archivo {pdf_file.name} -> {written} chunks escritos")
+                
+            except Exception as e:
+                reports.append(FileWithMetadataReport(
+                    file_path=pdf_file,
+                    success=False,
+                    chunks_written=0,
+                    doc_id="",
+                    error_message=str(e),
+                ))
+                print(f"❌ Error procesando {pdf_file.name}: {str(e)}")
+
+        return EmbedAndUpsertFilesWithMetadataOutput(
+            company_name=params.company_name,
+            area_name=params.area_name,
+            total_files=len(pdf_files),
+            successful_files=successful_count,
+            total_chunks_written=total_chunks,
+            reports=reports,
+        )
+
+    def _get_pdf_files(self, files_folder: Path) -> List[Path]:
+        """Get all PDF files from the files folder."""
+        if not files_folder.exists():
+            return []
+        
+        pdf_files: List[Path] = []
+        for file_path in files_folder.iterdir():
+            if file_path.is_file() and file_path.suffix.lower() == '.pdf':
+                pdf_files.append(file_path)
+        
+        return sorted(pdf_files)

--- a/app/ports/inbound/cli.py
+++ b/app/ports/inbound/cli.py
@@ -28,6 +28,9 @@ from app.application.use_cases.embed_and_upsert_pdf import (
 from app.application.use_cases.embed_and_upsert_company_pdfs import (
     EmbedAndUpsertCompanyPdfs, EmbedAndUpsertCompanyPdfsInput
 )
+from app.application.use_cases.embed_and_upsert_files_with_metadata import (
+    EmbedAndUpsertFilesWithMetadata, EmbedAndUpsertFilesWithMetadataInput
+)
 from app.domain.services.md_text_normalizer import MdTextNormalizer
 from app.ports.outbound.chunker import ChunkerConfig
 from app.adapters.chunker.chunk_global import ChunkGlobalAdapter
@@ -144,6 +147,20 @@ def main():
     ewc.add_argument("--q-alpha-min", type=float, default=0.30)
     ewc.add_argument("--q-uniq-min", type=float, default=0.10)
     ewc.add_argument("--generate-report", action="store_true", help="Generar reportes de extracción, normalización y chunking")
+
+    # --- upsert-company-files (archivos de company_files/files/ con metadata personalizada) ---
+    ucf = sub.add_parser("upsert-company-files", help="Procesar archivos de company_files/files/ con company_id y area personalizados")
+    ucf.add_argument("company_name", type=str, help="Nombre de la empresa (usado como company_id y nombre de colección)")
+    ucf.add_argument("area_name", type=str, help="Nombre del área (metadata area)")
+    ucf.add_argument("--max-pages", type=int, default=None)
+    ucf.add_argument("--target", type=int, default=512)
+    ucf.add_argument("--overlap", type=int, default=64)
+    ucf.add_argument("--min-toks", type=int, default=50)
+    ucf.add_argument("--sep", type=str, default="\n\n\f\n\n")
+    ucf.add_argument("--q-min-toks", type=int, default=50)
+    ucf.add_argument("--q-min-chars", type=int, default=200)
+    ucf.add_argument("--q-alpha-min", type=float, default=0.30)
+    ucf.add_argument("--q-uniq-min", type=float, default=0.10)
 
     # --- bedrock-check (sanity de conexión) ---
     br = sub.add_parser("bedrock-check", help="Probar conexión a Bedrock Titan con un texto")
@@ -421,6 +438,56 @@ def main():
             print(f"Archivos procesados: {out.successful_files}/{out.total_files}")
             print(f"Total chunks escritos: {out.total_chunks_written}")
             print(f"Colección: {args.company_id}")
+            
+            for report in out.reports:
+                status = "✅" if report.success else "❌"
+                if report.success:
+                    print(f"{status} {report.file_path.name} -> {report.chunks_written} chunks (doc_id: {report.doc_id})")
+                else:
+                    print(f"{status} {report.file_path.name} -> Error: {report.error_message}")
+        finally:
+            store.close()
+
+    elif args.cmd == "upsert-company-files":
+        blob = LocalFileSystemBlob()
+        extractor = PyMuPDFTextExtractor()
+        tokenizer = SimpleRegexTokenizer()
+        normalizer = MdTextNormalizer()
+        # Use semantic chunker for better results  
+        chunker = ChunkSemanticAdapter(
+            tokenizer,
+            ChunkerConfig(
+                target_tokens=args.target,
+                min_tokens=args.min_toks,
+                page_separator=args.sep,
+            ),
+        )
+        embedder = BedrockTitanEmbedder()
+        store = WeaviateVectorStore()
+
+        try:
+            uc = EmbedAndUpsertFilesWithMetadata(blob, extractor, normalizer, chunker, embedder, store)
+            out = uc.execute(EmbedAndUpsertFilesWithMetadataInput(
+                company_name=args.company_name,
+                area_name=args.area_name,
+                max_pages=args.max_pages,
+                chunker_cfg=ChunkerConfig(
+                    target_tokens=args.target,
+                    min_tokens=args.min_toks,
+                    page_separator=args.sep,
+                ),
+                quality_cfg=QualityConfig(
+                    min_tokens=args.q_min_toks,
+                    min_chars=args.q_min_chars,
+                    min_alpha_ratio=args.q_alpha_min,
+                    min_unique_ratio=args.q_uniq_min,
+                ),
+            ))
+
+            print(f"Company: {out.company_name} | Area: {out.area_name}")
+            print(f"Archivos procesados: {out.successful_files}/{out.total_files}")
+            print(f"Total chunks escritos: {out.total_chunks_written}")
+            print(f"Colección: {args.company_name}")
             
             for report in out.reports:
                 status = "✅" if report.success else "❌"


### PR DESCRIPTION
This pull request introduces a new CLI command and supporting use case for processing and embedding PDF files from a specific directory (`company_files/files/`), allowing users to specify custom metadata such as company and area names. The main changes include the addition of a new use case class, CLI integration for the new command, and related argument parsing and execution logic.

**New use case for embedding and upserting files with metadata:**

* Added the `EmbedAndUpsertFilesWithMetadata` class and related dataclasses in `embed_and_upsert_files_with_metadata.py`, enabling batch processing of PDF files with custom metadata, error handling, and reporting.

**CLI integration and command-line interface changes:**

* Registered the new `upsert-company-files` command in the CLI, including argument parsing for company name, area, chunking, and quality options.
* Implemented the execution logic for the `upsert-company-files` command, wiring together the new use case and outputting processing results and errors for each file.
* Imported the new use case and input dataclass in the CLI module to support the new command.